### PR TITLE
Missing backslash in moving and copying challange

### DIFF
--- a/02-create.md
+++ b/02-create.md
@@ -379,7 +379,7 @@ but it does find the copy in `thesis` that we didn't delete.
 > $ ls
 > proteins.dat
 > $ mkdir recombine
-> $ mv proteins.dat recombine
+> $ mv proteins.dat recombine/
 > $ cp recombine/proteins.dat ../proteins-saved.dat
 > $ ls
 > ~~~


### PR DESCRIPTION
This missing backslash in
mv proteins.dat recombine
renames proteins.dat to recombine rather than moving it to the recombine directory as intended.
ie should be mv proteins.dat recombine/
